### PR TITLE
Add ability to deploy via gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+install: true
 after_success: bash <(curl -s https://codecov.io/bash)
 notifications:
   email: false
@@ -8,3 +9,9 @@ notifications:
           - test-automation-tools:CMmRQOwodzTGByyGqAnySHHS#sunshine-robots
 
 script: ./gradlew
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 subprojects {
     apply plugin: 'java'
     group 'io.github.tatools'
-    version '0.1.0'
+    version '0.1.0-SNAPSHOT'
     sourceCompatibility = JavaVersion.VERSION_1_8
 
     repositories {
@@ -23,7 +23,7 @@ project(':sunshine-testng-integration-tests') {
 
 project(':sunshine') {
     dependencies {
-        compile project(':sunshine-tests-deps')
+        compileOnly project(':sunshine-tests-deps')
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# variables required to allow build.gradle to parse,
+# override in ~/.gradle/gradle.properties
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
+sonatypeUsername=
+sonatypePassword=

--- a/sunshine/build.gradle
+++ b/sunshine/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'jacoco'
+apply plugin: 'maven'
+apply plugin: 'signing'
 
 jacocoTestReport {
     reports {
@@ -26,10 +28,76 @@ copyJar.dependsOn(':sunshine-tests-deps:ready')
 
 test.dependsOn(copyJar)
 
-task ready(dependsOn: build) {
+task ready(dependsOn: test) {
     doLast {
         println("Sunshine unit testing is completed.")
     }
 }
 
 defaultTasks 'clean', 'ready'
+
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives jar
+    archives javadocJar
+    archives sourcesJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+
+            pom.project {
+                name "${project.name}"
+                packaging 'jar'
+                description "A Java library, with allows you to run your automated tests " +
+                        "without build systems (like maven, gradle)."
+                url 'https://github.com/tatools/sunshine'
+
+                scm {
+                    connection 'scm:git@github.com:tatools/sunshine.git'
+                    developerConnection 'scm:git@github.com:tatools/sunshine.git'
+                    url 'https://github.com/tatools/sunshine/tree/master'
+                }
+
+                licenses {
+                    license {
+                        name 'The Apache License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'extsoft'
+                        name 'Dmytro Serdiuk'
+                        email 'dmytro.serdiuk@gmail.com'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sunshine/src/main/java/io/github/tatools/sunshine/TestNGConfiguration.java
+++ b/sunshine/src/main/java/io/github/tatools/sunshine/TestNGConfiguration.java
@@ -15,7 +15,7 @@ public interface TestNGConfiguration {
     /**
      * Apply some modifications to an instance of {@link TestNG} before tests tun.
      *
-     * @param testNG
+     * @param testNG an instance to be configured
      */
     void apply(TestNG testNG);
 }


### PR DESCRIPTION
Change version to '0.1.0-SNAPSHOT'.
Add 'maven' and 'signing' plugins and configure them to publish data
to sonatype repository.
Add missing Javadoc.
Make 'sunshine-tests-deps' project as compile only dependency for
'sunshine'.

Closes #17