### PR TITLE
fixed JUnit test annotations, now all of them are referenced in imports

### DIFF
--- a/sunshine/src/test/java/io/github/tatools/sunshine/ClassAsTestTest.java
+++ b/sunshine/src/test/java/io/github/tatools/sunshine/ClassAsTestTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
  */
 public class ClassAsTestTest {
 
-    @org.junit.Test
+    @Test
     public void object() {
         MatcherAssert.assertThat(
                 new ClassAsTest("io/github/tatools/sunshine/ClassAsTest.class").object(),

--- a/sunshine/src/test/java/io/github/tatools/sunshine/ClasspathConfigTest.java
+++ b/sunshine/src/test/java/io/github/tatools/sunshine/ClasspathConfigTest.java
@@ -2,6 +2,7 @@ package io.github.tatools.sunshine;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
@@ -9,7 +10,7 @@ import org.hamcrest.Matchers;
  */
 public class ClasspathConfigTest {
 
-    @org.junit.Test
+    @Test
     public void propertyReturnNotDefinedForUnknownKey() {
         MatcherAssert.assertThat(
                 new ClasspathConfig("test.properties").property("a"),

--- a/sunshine/src/test/java/io/github/tatools/sunshine/PatternRuleTest.java
+++ b/sunshine/src/test/java/io/github/tatools/sunshine/PatternRuleTest.java
@@ -1,13 +1,15 @@
 package io.github.tatools.sunshine;
 
 import org.hamcrest.MatcherAssert;
+import org.junit.Test;
 
 /**
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 21.04.2017
  */
 public class PatternRuleTest {
-    @org.junit.Test
+
+    @Test
     public void relevant() {
         MatcherAssert.assertThat(
                 "Regex doesn't work",

--- a/sunshine/src/test/java/io/github/tatools/sunshine/ReportFolderTest.java
+++ b/sunshine/src/test/java/io/github/tatools/sunshine/ReportFolderTest.java
@@ -2,13 +2,15 @@ package io.github.tatools.sunshine;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 21.04.2017
  */
 public class ReportFolderTest {
-    @org.junit.Test
+
+    @Test
     public void value() {
         MatcherAssert.assertThat(
                 new ReportFolder(new ClasspathConfig("test.properties")).value(),

--- a/sunshine/src/test/java/io/github/tatools/sunshine/SunshineConfigTest.java
+++ b/sunshine/src/test/java/io/github/tatools/sunshine/SunshineConfigTest.java
@@ -1,11 +1,14 @@
 package io.github.tatools.sunshine;
 
+import org.junit.Test;
+
 /**
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 21.04.2017
  */
 public class SunshineConfigTest {
-    @org.junit.Test
+
+    @Test
     public void property() {
         new SunshineConfig().property("dad");
     }


### PR DESCRIPTION
Replaced all `@org.junit.Test` annotations to 'import org.junit.Test; ... @Test' 

Closes #54