### PR TITLE
Use EngineException to handle Engine level errors

### DIFF
--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Engine.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Engine.java
@@ -11,10 +11,9 @@ public interface Engine<Listener> {
     /**
      * Runs tests in an engine.
      *
-     * @throws SuiteException if some error occurs
+     * @throws EngineException if some error occurs
      */
-//    @todo #90:30m Create separate exception for Engine errors.
-    void run() throws SuiteException;
+    void run() throws EngineException;
 
     /**
      * Allow to get new instance of an engine with provided listeners.

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/EngineException.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/EngineException.java
@@ -1,0 +1,22 @@
+package io.github.tatools.sunshine.core;
+
+/**
+ * The {@link EngineException} class is a default exception to handle errors which may occur in the implementations of
+ * an {@link Engine}.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 04.07.2017
+ */
+public class EngineException extends SunshineException {
+    public EngineException(String message) {
+        super(message);
+    }
+
+    public EngineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EngineException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Junit4Engine.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Junit4Engine.java
@@ -1,6 +1,7 @@
 package io.github.tatools.sunshine.junit4;
 
 import io.github.tatools.sunshine.core.Engine;
+import io.github.tatools.sunshine.core.EngineException;
 import io.github.tatools.sunshine.core.Suite;
 import io.github.tatools.sunshine.core.SuiteException;
 import org.junit.runner.Computer;
@@ -29,17 +30,21 @@ public final class Junit4Engine implements Engine<RunListener> {
     }
 
     @Override
-    public void run() throws SuiteException {
-        Result result = jUnitCore.run(new Computer(), suite.tests());
-        System.out.println(
-                String.format(
-                        "Total tests run: %s, Failures: %s, Skips: %s",
-                        result.getRunCount(),
-                        result.getFailureCount(),
-                        result.getIgnoreCount()
-                )
-        );
-        System.exit(result.wasSuccessful() ? 0 : -1);
+    public void run() throws EngineException {
+        try {
+            Result result = jUnitCore.run(new Computer(), suite.tests());
+            System.out.println(
+                    String.format(
+                            "Total tests run: %s, Failures: %s, Skips: %s",
+                            result.getRunCount(),
+                            result.getFailureCount(),
+                            result.getIgnoreCount()
+                    )
+            );
+            System.exit(result.wasSuccessful() ? 0 : -1);
+        } catch (SuiteException e) {
+            throw new EngineException("Some problem occurs in the Junit4 engine", e);
+        }
     }
 
     @Override

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Sunshine.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Sunshine.java
@@ -11,7 +11,7 @@ import io.github.tatools.sunshine.core.*;
  */
 public final class Sunshine {
 
-    public static void main(String[] args) throws SuiteException {
+    public static void main(String[] args) throws EngineException {
         new Junit4Engine(
                 new JunitSuite(
                         new FileSystemOfClasspathClasses(),

--- a/sunshine-junit4/src/test/java/io/github/tatools/sunshine/junit4/Junit4EngineTest.java
+++ b/sunshine-junit4/src/test/java/io/github/tatools/sunshine/junit4/Junit4EngineTest.java
@@ -1,0 +1,24 @@
+package io.github.tatools.sunshine.junit4;
+
+import io.github.tatools.sunshine.core.EngineException;
+import io.github.tatools.sunshine.core.SuiteException;
+import org.junit.Test;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 04.07.2017
+ */
+public class Junit4EngineTest {
+
+    @Test
+    public void run() throws EngineException {
+        new Junit4Engine(() -> new Class[]{}).run();
+    }
+
+    @Test(expected = EngineException.class)
+    public void runWithFail() throws EngineException {
+        new Junit4Engine(() -> {
+            throw new SuiteException("Fail");
+        }).run();
+    }
+}

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/Sunshine.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/Sunshine.java
@@ -13,7 +13,7 @@ import io.github.tatools.sunshine.core.*;
  */
 public final class Sunshine {
 
-    public static void main(String[] args) throws SuiteException {
+    public static void main(String[] args) throws EngineException {
         if (args != null && args.length > 0) {
             new TestNGEngine(new PreparedTestNGSuite(args[0])).run();
         } else {

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGEngine.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGEngine.java
@@ -1,6 +1,7 @@
 package io.github.tatools.sunshine.testng;
 
 import io.github.tatools.sunshine.core.Engine;
+import io.github.tatools.sunshine.core.EngineException;
 import io.github.tatools.sunshine.core.FileSystem;
 import io.github.tatools.sunshine.core.SuiteException;
 import org.testng.ITestNGListener;
@@ -36,10 +37,14 @@ public final class TestNGEngine implements Engine<ITestNGListener> {
     }
 
     @Override
-    public void run() throws SuiteException {
-        engine.setTestSuites(Collections.singletonList(tests.tests().path().toString()));
-        engine.run();
-        System.exit(engine.getStatus());
+    public void run() throws EngineException {
+        try {
+            engine.setTestSuites(Collections.singletonList(tests.tests().path().toString()));
+            engine.run();
+            System.exit(engine.getStatus());
+        } catch (SuiteException e) {
+            throw new EngineException("Some problem occurs in the TestNG engine", e);
+        }
     }
 
     /**

--- a/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/TestNGEngineTest.java
+++ b/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/TestNGEngineTest.java
@@ -1,0 +1,25 @@
+package io.github.tatools.sunshine.testng;
+
+import io.github.tatools.sunshine.core.EngineException;
+import io.github.tatools.sunshine.core.FsPath;
+import io.github.tatools.sunshine.core.SuiteException;
+import org.junit.Test;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 04.07.2017
+ */
+public class TestNGEngineTest {
+
+    @Test
+    public void run() throws EngineException {
+        new TestNGEngine(() -> new FsPath.Fake("src/test/resources/testng.xml")).run();
+    }
+
+    @Test(expected = EngineException.class)
+    public void runWithFail() throws EngineException {
+        new TestNGEngine(() -> {
+            throw new SuiteException("Fail");
+        }).run();
+    }
+}

--- a/sunshine-testng/src/test/resources/testng.xml
+++ b/sunshine-testng/src/test/resources/testng.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Sunshine TestNG integration tests">
+    <test name="1"/>
+</suite>


### PR DESCRIPTION
EngineException.java was added to handle errors of an Engine.
All Engine's implementations will throw an EngineException if any error
occurs.

Add unit tests to test new behaviour.

Affects #100