### PR TITLE
Rename SunshineSuite implementations

### DIFF
--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineSuiteBase.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineSuiteBase.java
@@ -8,18 +8,19 @@ import java.util.stream.Collectors;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 20.03.2017
  */
-public final class BaseSuite implements SunshineSuite {
-    // @todo #99:1h Make names self-explained for SunshineSuite implementaions.
+public final class SunshineSuiteBase implements SunshineSuite {
     private final FileSystem fileSystem;
 
-    public BaseSuite(FileSystem fileSystem) {
+    public SunshineSuiteBase(FileSystem fileSystem) {
         this.fileSystem = fileSystem;
     }
 
     @Override
     public List<SunshineTest> tests() throws SuiteException {
         try {
-            return fileSystem.files().stream().map(f -> new BaseTest(f.path().toString())).collect(Collectors.toList());
+            return fileSystem.files().stream()
+                    .map(f -> new SunshineTestBase(f.path().toString()))
+                    .collect(Collectors.toList());
         } catch (FileSystemException e) {
             throw new SuiteException(e);
         }

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineSuiteFilterable.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineSuiteFilterable.java
@@ -7,12 +7,12 @@ import java.util.stream.Collectors;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 21.04.2017
  */
-public final class FilterableSuite implements SunshineSuite {
+public final class SunshineSuiteFilterable implements SunshineSuite {
 
     private final SunshineSuite suite;
     private final Condition filter;
 
-    public FilterableSuite(SunshineSuite suite, Condition filter) {
+    public SunshineSuiteFilterable(SunshineSuite suite, Condition filter) {
         this.suite = suite;
         this.filter = filter;
     }

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineSuitePrintable.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineSuitePrintable.java
@@ -6,11 +6,11 @@ import java.util.List;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 10.06.2017
  */
-public final class PrintableSuite implements SunshineSuite {
+public final class SunshineSuitePrintable implements SunshineSuite {
 
     private final SunshineSuite sunshineSuite;
 
-    public PrintableSuite(SunshineSuite sunshineSuite) {
+    public SunshineSuitePrintable(SunshineSuite sunshineSuite) {
         this.sunshineSuite = sunshineSuite;
     }
 

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineTestBase.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/SunshineTestBase.java
@@ -7,10 +7,10 @@ import lombok.EqualsAndHashCode;
  * @since 18.03.2017
  */
 @EqualsAndHashCode
-public final class BaseTest implements SunshineTest {
+public final class SunshineTestBase implements SunshineTest {
     private final String path;
 
-    public BaseTest(String path) {
+    public SunshineTestBase(String path) {
         this.path = path;
     }
 

--- a/sunshine-core/src/test/java/io/github/tatools/sunshine/core/SunshineSuitePrintableTest.java
+++ b/sunshine-core/src/test/java/io/github/tatools/sunshine/core/SunshineSuitePrintableTest.java
@@ -9,13 +9,13 @@ import org.junit.Test;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 10.06.2017
  */
-public class PrintableSuiteTest {
+public class SunshineSuitePrintableTest {
 
     @Test
     public void tests() throws TestException, SuiteException {
         final SunshineTest.Fake test = new SunshineTest.Fake();
         MatcherAssert.assertThat(
-                new PrintableSuite(new SunshineSuite.Fake(test)).tests(),
+                new SunshineSuitePrintable(new SunshineSuite.Fake(test)).tests(),
                 Matchers.contains(test)
         );
     }

--- a/sunshine-core/src/test/java/io/github/tatools/sunshine/core/SunshineTestTestBase.java
+++ b/sunshine-core/src/test/java/io/github/tatools/sunshine/core/SunshineTestTestBase.java
@@ -8,21 +8,21 @@ import org.junit.Test;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @since 22.04.2017
  */
-public class BaseTestTest {
+public class SunshineTestTestBase {
 
     @Test
     public void object() throws TestException {
         MatcherAssert.assertThat(
-                new BaseTest("io/github/tatools/sunshine/core/BaseTest.class").object(),
-                Matchers.equalTo(BaseTest.class)
+                new SunshineTestBase("io/github/tatools/sunshine/core/SunshineTestBase.class").object(),
+                Matchers.equalTo(SunshineTestBase.class)
         );
     }
 
     @Test
     public void toStringImpl() {
         MatcherAssert.assertThat(
-                new BaseTest("io/github/tatools/sunshine/core/BaseTest.class").toString(),
-                Matchers.equalTo("io.github.tatools.sunshine.core.BaseTest")
+                new SunshineTestBase("io/github/tatools/sunshine/core/SunshineTestBase.class").toString(),
+                Matchers.equalTo("io.github.tatools.sunshine.core.SunshineTestBase")
         );
     }
 }

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/JunitSuite.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/JunitSuite.java
@@ -14,7 +14,7 @@ public final class JunitSuite implements Suite<Class<?>[]> {
     private final SunshineSuite classesAsSuite;
 
     public JunitSuite(FileSystem fileSystem, Condition filter) {
-        this(new PrintableSuite(new FilterableSuite(new BaseSuite(fileSystem), filter)));
+        this(new SunshineSuitePrintable(new SunshineSuiteFilterable(new SunshineSuiteBase(fileSystem), filter)));
     }
 
     public JunitSuite(SunshineSuite classesAsSuite) {

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/LoadableTestNGSuite.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/LoadableTestNGSuite.java
@@ -20,7 +20,10 @@ public final class LoadableTestNGSuite implements TestNGSuite {
     }
 
     public LoadableTestNGSuite(FileSystem fileSystem, Directory suitePath, Condition filter) {
-        this(new PrintableSuite(new FilterableSuite(new BaseSuite(fileSystem), filter)), suitePath);
+        this(
+                new SunshineSuitePrintable(new SunshineSuiteFilterable(new SunshineSuiteBase(fileSystem), filter)),
+                suitePath
+        );
     }
 
     public LoadableTestNGSuite(SunshineSuite artifacts, Directory suitePath) {

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGTest.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGTest.java
@@ -18,7 +18,7 @@ final class TestNGTest implements Test<XmlTest> {
     }
 
     TestNGTest(String clazz) {
-        this(new BaseTest(clazz));
+        this(new SunshineTestBase(clazz));
     }
 
     @Override


### PR DESCRIPTION
All implementations of SunshineSuite will start from
'SunshineSuite + some suffix'. This allows to decrease misunderstanding
in names of classes.

Affects #106