### PR TITLE
Automate the interactions with the staging repo

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -30,3 +30,4 @@ release:
     ./gradlew updateVersion -PnewVersion=${tag}
     git commit -am "${tag}"
     ./gradlew -i clean uploadArchives
+    ./gradlew closeAndReleaseRepository

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,17 @@
 import groovy.io.FileType
 
+plugins {
+    id 'io.codearte.nexus-staging' version '0.9.0'
+}
+
+// configure "nexus-staging" plugin
+nexusStaging {
+    packageGroup= "io.github.tatools"
+    delayBetweenRetriesInMillis = 60000
+    username = sonatypeUsername
+    password = sonatypePassword
+}
+
 subprojects {
     apply plugin: 'java'
     group 'io.github.tatools'


### PR DESCRIPTION
Now 'close' and 'release' phases on staging repository are
automated with Rultor and gradle-nexus-staging-plugin.

Closes #119