### PR TITLE
Unify engines' output

### DIFF
--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Engine.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Engine.java
@@ -6,14 +6,20 @@ package io.github.tatools.sunshine.core;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @deprecated since 0.2. Use {@link Kernel} instead.
  */
+@Deprecated
 public interface Engine<Listener> {
 
     /**
      * Runs tests in an engine.
      *
      * @throws EngineException if some error occurs
+     * @deprecated since 0.2. Use {@link Kernel#status()} instead. Please notice that {@link Kernel#status()} doesn't
+     * call {@link System#exit(int)} in the end of tests execution. If you want to do that, please take a look for a
+     * {@link Star}.
      */
+    @Deprecated
     void run() throws EngineException;
 
     /**
@@ -21,6 +27,8 @@ public interface Engine<Listener> {
      *
      * @param listeners an instance (or instances) of engine's listeners
      * @return new instance of an engine
+     * @deprecated since 0.2. Use {@link Kernel#with(Object[])} instead.
      */
+    @Deprecated
     Engine<Listener> with(Listener... listeners);
 }

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Kernel.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Kernel.java
@@ -1,0 +1,46 @@
+package io.github.tatools.sunshine.core;
+
+/**
+ * The {@link Kernel} interface declares a way to implement different xnit test runners.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public interface Kernel<Listener> {
+
+    /**
+     * Provides information about tests run.
+     *
+     * @return the status of a tests run
+     * @throws KernelException if any error occurs
+     */
+    Status status() throws KernelException;
+
+    /**
+     * Returns new instance of a kernel with provided listeners.
+     *
+     * @param listeners an instance (or instances) of kernel's listeners
+     * @return the new instance of a kernel
+     */
+    Kernel<Listener> with(Listener... listeners);
+
+    final class Fake implements Kernel {
+
+        private final Status result;
+
+        public Fake(Status status) {
+            this.result = status;
+        }
+
+        @Override
+        public Status status() {
+            return this.result;
+        }
+
+        @Override
+        public Kernel<?> with(Object[] objects) {
+            return null;
+        }
+    }
+}

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/KernelException.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/KernelException.java
@@ -1,0 +1,23 @@
+package io.github.tatools.sunshine.core;
+
+/**
+ * The {@link KernelException} class is a default exception to handle errors which may occur in the implementations of
+ * an {@link Kernel}.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class KernelException extends SunshineException {
+    public KernelException(String message) {
+        super(message);
+    }
+
+    public KernelException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public KernelException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Star.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Star.java
@@ -1,0 +1,19 @@
+package io.github.tatools.sunshine.core;
+
+/**
+ * The {@link Star} interface provides a contract to use {@link Kernel}s. The root idea is that a {@link Star} can
+ * shine only it has a {@link Kernel}. And a {@link Kernel} is always a part of a {@link Star}.
+ * <p>The interface is a top level abstraction of the Sunshine.</p>
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @see Sun
+ * @since 0.2
+ */
+@FunctionalInterface
+public interface Star {
+    /**
+     * Allows this star to shine with an encapsulated {@link Kernel}(s).
+     */
+    void shine();
+}

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Status.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Status.java
@@ -1,0 +1,77 @@
+package io.github.tatools.sunshine.core;
+
+/**
+ * The {@link Status} interface declares a way to retrieve tests run status.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public interface Status {
+
+    /**
+     * Returns the exit code of an execution provided by xunit tests runner.
+     *
+     * @return the exit code
+     */
+    short code();
+
+    /**
+     * Returns a count of tests were run by a xunit runner.
+     *
+     * @return the count of total tests
+     */
+    int runCount();
+
+    /**
+     * Returns a count of failed tests were run by a xunit runner.
+     *
+     * @return the count of failed tests
+     */
+    int failureCount();
+
+    /**
+     * Returns a count of ignored or skipped tests were run by a xunit runner.
+     *
+     * @return the count of ignored tests
+     */
+    int ignoreCount();
+
+    final class Fake implements Status {
+        private final short c;
+        private final int r;
+        private final int f;
+        private final int i;
+
+        public Fake() {
+            this((short) 0, 5, 0, 1);
+        }
+
+        public Fake(short code, int total, int failed, int ignored) {
+            this.c = code;
+            this.r = total;
+            this.f = failed;
+            this.i = ignored;
+        }
+
+        @Override
+        public short code() {
+            return this.c;
+        }
+
+        @Override
+        public int runCount() {
+            return this.r;
+        }
+
+        @Override
+        public int failureCount() {
+            return this.f;
+        }
+
+        @Override
+        public int ignoreCount() {
+            return this.i;
+        }
+    }
+}

--- a/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Sun.java
+++ b/sunshine-core/src/main/java/io/github/tatools/sunshine/core/Sun.java
@@ -1,0 +1,50 @@
+package io.github.tatools.sunshine.core;
+
+/**
+ * The {@link Sun} class provides an implementation of a {@link Star} especially designed for continuous integration
+ * servers. If any errors occur during tests execution, a continuous integration server will fail the job's execution.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public final class Sun implements Star {
+
+    private static final int SUNSHINE_ERROR = 12;
+    private final Kernel<?> core;
+
+    /**
+     * Constructs the new instance.
+     *
+     * @param kernel the {@link Kernel}
+     */
+    public Sun(Kernel<?> kernel) {
+        this.core = kernel;
+    }
+
+    /**
+     * Retrieves a {@link Status} of encapsulated {@link Kernel}. If there are some errors in suite's preparation, the
+     * execution will be aborted with exit code #{@value SUNSHINE_ERROR}, otherwise exit code will be provided by
+     * appropriate {@link Kernel}.
+     */
+    @Override
+    public void shine() {
+        try {
+            final Status status = this.core.status();
+            System.out.println(
+                    new StringBuilder("\n===============================================\n")
+                            .append("Total tests run: ")
+                            .append(status.runCount())
+                            .append(", Failures: ")
+                            .append(status.failureCount())
+                            .append(", Skips: ")
+                            .append(status.ignoreCount())
+                            .append("\n===============================================\n")
+            );
+            System.exit(status.code());
+        } catch (KernelException e) {
+            e.printStackTrace(System.out);
+            System.exit(Sun.SUNSHINE_ERROR);
+        }
+    }
+}

--- a/sunshine-core/src/test/java/io/github/tatools/sunshine/core/SunTest.java
+++ b/sunshine-core/src/test/java/io/github/tatools/sunshine/core/SunTest.java
@@ -1,0 +1,17 @@
+package io.github.tatools.sunshine.core;
+
+import io.github.tatools.sunshine.core.Status.Fake;
+import org.junit.Test;
+
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class SunTest {
+    @Test
+    public void shine() {
+        new Sun(new Kernel.Fake(new Fake())).shine();
+    }
+}

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Junit4Engine.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Junit4Engine.java
@@ -15,12 +15,20 @@ import java.util.Arrays;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @deprecated since 0.2. Use {@link Junit4Kernel} instead. Please pay attention to {@link Engine#run()}.
  */
+@Deprecated
 public final class Junit4Engine implements Engine<RunListener> {
 
     private final JUnitCore jUnitCore;
     private final Suite<Class<?>[]> suite;
 
+    /**
+     * Constructs the new instance.
+     *
+     * @param suite the suite to be used
+     * @deprecated since 0.2.
+     */
     public Junit4Engine(Suite<Class<?>[]> suite) {
         this(new JUnitCore(), suite);
     }

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Junit4Kernel.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Junit4Kernel.java
@@ -1,0 +1,64 @@
+package io.github.tatools.sunshine.junit4;
+
+import io.github.tatools.sunshine.core.*;
+import org.junit.runner.Computer;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.notification.RunListener;
+
+import java.util.Arrays;
+
+/**
+ * The class provides a {@link Kernel} implementation of JUnit runner.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class Junit4Kernel implements Kernel<RunListener> {
+
+    private final JUnitCore junit;
+    private final Suite<Class<?>[]> suiteForRun;
+
+    /**
+     * Initializes a newly created {@link Junit4Kernel} object so that it represents
+     * an JUnit4 runner.
+     *
+     * @param suite the tests suite
+     */
+    public Junit4Kernel(Suite<Class<?>[]> suite) {
+        this(new JUnitCore(), suite);
+    }
+
+    private Junit4Kernel(JUnitCore jUnitCore, Suite<Class<?>[]> suite) {
+        this.junit = jUnitCore;
+        this.suiteForRun = suite;
+    }
+
+    /**
+     * Returns status of JUnite tests execution.
+     *
+     * @return the status
+     * @throws KernelException if any error occurs during JUnit tests execution.
+     */
+    @Override
+    public Status status() throws KernelException {
+        try {
+            return new JunitStatus(this.junit.run(new Computer(), this.suiteForRun.tests()));
+        } catch (SuiteException e) {
+            throw new KernelException("Some problem occurs in the Junit4Kernel", e);
+        }
+    }
+
+    /**
+     * Returns new instance of the JUnit kernel with provided listeners.
+     *
+     * @param listeners an instance (or instances) of JUnit listeners
+     * @return the new instance of the JUnit kernel
+     */
+    @Override
+    public Junit4Kernel with(RunListener... listeners) {
+        final JUnitCore jUnitCore = new JUnitCore();
+        Arrays.stream(listeners).forEach(jUnitCore::addListener);
+        return new Junit4Kernel(jUnitCore, this.suiteForRun);
+    }
+}

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/JunitStatus.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/JunitStatus.java
@@ -1,0 +1,49 @@
+package io.github.tatools.sunshine.junit4;
+
+import io.github.tatools.sunshine.core.Status;
+import org.junit.runner.Result;
+
+/**
+ * The class provides an implementation of the {@link Status} of JUnit execution.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public final class JunitStatus implements Status {
+
+    private final Result status;
+
+    /**
+     * Initializes a newly created {@link JunitStatus} object so that it represents
+     * a status of JUnit4 execution.
+     *
+     * @param result the Junit4 result
+     */
+    public JunitStatus(Result result) {
+        this.status = result;
+    }
+
+    @Override
+    public short code() {
+        if (this.status.wasSuccessful()) {
+            return (short) 0;
+        }
+        return (short) 1;
+    }
+
+    @Override
+    public int runCount() {
+        return status.getRunCount();
+    }
+
+    @Override
+    public int failureCount() {
+        return status.getFailureCount();
+    }
+
+    @Override
+    public int ignoreCount() {
+        return status.getIgnoreCount();
+    }
+}

--- a/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Sunshine.java
+++ b/sunshine-junit4/src/main/java/io/github/tatools/sunshine/junit4/Sunshine.java
@@ -12,20 +12,22 @@ import io.github.tatools.sunshine.core.*;
  */
 public final class Sunshine {
 
-    public static void main(String[] args) throws EngineException {
-        new Junit4Engine(
-                new JunitSuite(
-                        new FileSystemOfClasspathClasses(),
-                        new RegexCondition(
-                                new AttributeWithPrintableValue(
-                                        "The following pattern will be used for classes filtering:",
-                                        new AttributeFromSequence(
-                                                new AttributeOfTestPatternFromCli(),
-                                                new AttributeOfTestPatternFromConfig(new ConfigFromSunshine())
+    public static void main(String[] args) {
+        new Sun(
+                new Junit4Kernel(
+                        new JunitSuite(
+                                new FileSystemOfClasspathClasses(),
+                                new RegexCondition(
+                                        new AttributeWithPrintableValue(
+                                                "The following pattern will be used for classes filtering:",
+                                                new AttributeFromSequence(
+                                                        new AttributeOfTestPatternFromCli(),
+                                                        new AttributeOfTestPatternFromConfig(new ConfigFromSunshine())
+                                                )
                                         )
                                 )
                         )
                 )
-        ).run();
+        ).shine();
     }
 }

--- a/sunshine-junit4/src/test/java/io/github/tatools/sunshine/junit4/Junit4KernelTest.java
+++ b/sunshine-junit4/src/test/java/io/github/tatools/sunshine/junit4/Junit4KernelTest.java
@@ -1,0 +1,64 @@
+package io.github.tatools.sunshine.junit4;
+
+import io.github.tatools.sunshine.core.KernelException;
+import io.github.tatools.sunshine.core.SuiteException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class Junit4KernelTest {
+
+    @Test
+    public void run() throws KernelException {
+        MatcherAssert.assertThat(
+                new Junit4Kernel(() -> new Class[]{}).status().code(),
+                Matchers.equalTo((short) 0)
+        );
+    }
+
+    @Test(expected = KernelException.class)
+    public void runWithFail() throws KernelException {
+        new Junit4Kernel(() -> {
+            throw new SuiteException("Fail");
+        }).status();
+    }
+
+    @Test
+    public void with() throws KernelException {
+        final Listener l1 = new Listener();
+        final Listener l2 = new Listener();
+        new Junit4Kernel(() -> new Class[]{}).with(l1).with(l2).status();
+        MatcherAssert.assertThat(l1, Matchers.not(Matchers.equalTo(l2)));
+    }
+
+    private static final class Listener extends RunListener {
+        private int status = 0;
+
+        @Override
+        public void testRunStarted(Description description) throws Exception {
+            status++;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Junit4KernelTest.Listener listener = (Junit4KernelTest.Listener) o;
+
+            return this.status == listener.status;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.status;
+        }
+    }
+}

--- a/sunshine-junit4/src/test/java/io/github/tatools/sunshine/junit4/JunitStatusTest.java
+++ b/sunshine-junit4/src/test/java/io/github/tatools/sunshine/junit4/JunitStatusTest.java
@@ -1,0 +1,89 @@
+package io.github.tatools.sunshine.junit4;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.Result;
+
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class JunitStatusTest {
+    @Test
+    public void codeIfPassed() {
+        MatcherAssert.assertThat(
+                new JunitStatus(new FakeResult(true, 0, 0, 0)).code(),
+                Matchers.is(0)
+        );
+    }
+
+    @Test
+    public void codeIfFailed() {
+        MatcherAssert.assertThat(
+                new JunitStatus(new FakeResult(false, 0, 0, 0)).code(),
+                Matchers.is(1)
+        );
+    }
+
+    @Test
+    public void runCount() {
+        MatcherAssert.assertThat(
+                new JunitStatus(new FakeResult(false, 3, 0, 0)).runCount(),
+                Matchers.is(3)
+        );
+    }
+
+    @Test
+    public void failureCount() {
+        MatcherAssert.assertThat(
+                new JunitStatus(new FakeResult(false, 0, 2, 0)).failureCount(),
+                Matchers.is(2)
+        );
+    }
+
+    @Test
+    public void ignoreCount() {
+        MatcherAssert.assertThat(
+                new JunitStatus(new FakeResult(false, 0, 0, 5)).ignoreCount(),
+                Matchers.is(5)
+        );
+    }
+
+    private final class FakeResult extends Result {
+        private static final long serialVersionUID = -7061965103897931256L;
+        private final boolean wasSuccessful;
+        private final int runCount;
+        private final int failureCount;
+        private final int ignoreCount;
+
+        FakeResult(boolean successful, int total, int failed, int ignored) {
+            this.wasSuccessful = successful;
+            this.runCount = total;
+            this.failureCount = failed;
+            this.ignoreCount = ignored;
+        }
+
+        @Override
+        public int getRunCount() {
+            return this.runCount;
+        }
+
+        @Override
+        public int getFailureCount() {
+            return this.failureCount;
+        }
+
+        @Override
+        public int getIgnoreCount() {
+            return this.ignoreCount;
+        }
+
+        @Override
+        public boolean wasSuccessful() {
+            return this.wasSuccessful;
+        }
+    }
+}

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/CachedTestNGSuite.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/CachedTestNGSuite.java
@@ -10,12 +10,19 @@ import java.util.List;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @deprecated since 0.2. Will be removed in the future.
  */
+@Deprecated
 public final class CachedTestNGSuite implements TestNGSuite {
 
     private final List<FileSystemPath> files = new ArrayList<>(1);
     private final TestNGSuite testNGSuite;
 
+    /**
+     * @param testNGSuite
+     * @deprecated since 0.2
+     */
+    @Deprecated
     public CachedTestNGSuite(TestNGSuite testNGSuite) {
         this.testNGSuite = testNGSuite;
     }

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/Sunshine.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/Sunshine.java
@@ -14,12 +14,12 @@ import io.github.tatools.sunshine.core.*;
  */
 public final class Sunshine {
 
-    public static void main(String[] args) throws EngineException {
+    public static void main(String[] args) {
         if (args != null && args.length > 0) {
-            new TestNGEngine(new PreparedTestNGSuite(args[0])).run();
+            new Sun(new TestNGKernel(new PreparedTestNGSuite(args[0]))).shine();
         } else {
-            new TestNGEngine(
-                    new CachedTestNGSuite(
+            new Sun(
+                    new TestNGKernel(
                             new LoadableTestNGSuite(
                                     new FileSystemOfClasspathClasses(),
                                     new RegexCondition(
@@ -35,7 +35,7 @@ public final class Sunshine {
                                     )
                             )
                     )
-            ).run();
+            ).shine();
         }
     }
 }

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/SunshineTestNG.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/SunshineTestNG.java
@@ -1,0 +1,37 @@
+package io.github.tatools.sunshine.testng;
+
+import org.testng.ISuite;
+import org.testng.TestNG;
+
+import java.util.List;
+
+/**
+ * The {@link SunshineTestNG} class is the default configuration of TestNG defined for Sunshine.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+final class SunshineTestNG extends TestNG {
+
+    private final List<ISuite> database;
+
+    /**
+     * Constructs the instance of TestNG without default listeners and with 0 verbose mode (no logs). All executed
+     * suites will be saved to a given list.
+     *
+     * @param suitesHolder the list to store suites
+     */
+    SunshineTestNG(List<ISuite> suitesHolder) {
+        super(false);
+        this.database = suitesHolder;
+        this.setVerbose(0);
+    }
+
+    @Override
+    protected List<ISuite> runSuites() {
+        final List<ISuite> suites = super.runSuites();
+        this.database.addAll(suites);
+        return suites;
+    }
+}

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGEngine.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGEngine.java
@@ -16,7 +16,9 @@ import java.util.Collections;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @deprecated since 0.2. Use {@link TestNGKernel} instead. Please pay attention to {@link Engine#run()}.
  */
+@Deprecated
 public final class TestNGEngine implements Engine<ITestNGListener> {
 
     private final TestNG engine;
@@ -27,7 +29,9 @@ public final class TestNGEngine implements Engine<ITestNGListener> {
      * an TestNG runner.
      *
      * @param tests an instance of a {@link TestNGSuite} where need to find tests
+     * @deprecated since 0.2.
      */
+    @Deprecated
     public TestNGEngine(TestNGSuite tests) {
         this(new TestNG(false), tests);
     }
@@ -40,9 +44,9 @@ public final class TestNGEngine implements Engine<ITestNGListener> {
     @Override
     public void run() throws EngineException {
         try {
-            engine.setTestSuites(Collections.singletonList(tests.tests().path().toString()));
-            engine.run();
-            System.exit(engine.getStatus());
+            this.engine.setTestSuites(Collections.singletonList(this.tests.tests().path().toString()));
+            this.engine.run();
+            System.exit(this.engine.getStatus());
         } catch (SuiteException e) {
             throw new EngineException("Some problem occurs in the TestNG engine", e);
         }
@@ -58,6 +62,6 @@ public final class TestNGEngine implements Engine<ITestNGListener> {
     public TestNGEngine with(ITestNGListener... listeners) {
         final TestNG testNG = new TestNG(false);
         Arrays.stream(listeners).forEach(testNG::addListener);
-        return new TestNGEngine(testNG, tests);
+        return new TestNGEngine(testNG, this.tests);
     }
 }

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGKernel.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGKernel.java
@@ -1,0 +1,63 @@
+package io.github.tatools.sunshine.testng;
+
+import io.github.tatools.sunshine.core.*;
+import org.testng.ISuite;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The {@link TestNGKernel} class allows to run TestNG for given {@link FileSystem}.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public final class TestNGKernel implements Kernel<ITestNGListener> {
+
+    private final TestNG engine;
+    private final TestNGSuite suite;
+    private final List<ISuite> suites;
+
+    /**
+     * Initializes a newly created {@link TestNGKernel} object so that it represents
+     * an TestNG runner.
+     *
+     * @param tests an instance of a {@link TestNGSuite} where need to find tests
+     */
+    public TestNGKernel(TestNGSuite tests) {
+        this.suites = new ArrayList<>();
+        this.engine = new SunshineTestNG(this.suites);
+        this.suite = tests;
+    }
+
+
+    @Override
+    public Status status() throws KernelException {
+        try {
+            this.suites.clear();
+            this.engine.setTestSuites(Collections.singletonList(this.suite.tests().path().toString()));
+            this.engine.run();
+            return new TestNGStatus(engine.getStatus(), this.suites);
+        } catch (SuiteException e) {
+            throw new KernelException("Some problem occurs in the TestNGKernel", e);
+        }
+    }
+
+    /**
+     * Constructs new {@link TestNGKernel} object with wanted listeners.
+     *
+     * @param listeners an instance (or instances) of engine's listeners
+     * @return an instance of {@link TestNGKernel}
+     */
+    @Override
+    public TestNGKernel with(ITestNGListener... listeners) {
+        final TestNGKernel kernel = new TestNGKernel(this.suite);
+        Arrays.stream(listeners).forEach(kernel.engine::addListener);
+        return kernel;
+    }
+}

--- a/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGStatus.java
+++ b/sunshine-testng/src/main/java/io/github/tatools/sunshine/testng/TestNGStatus.java
@@ -1,0 +1,72 @@
+package io.github.tatools.sunshine.testng;
+
+import io.github.tatools.sunshine.core.Status;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.ITestContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The class provides an implementation of the {@link Status} of TestNG execution.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public final class TestNGStatus implements Status {
+
+    private final short exit_code;
+    private final List<ISuite> reports;
+    private final List<Integer> counts;
+
+    public TestNGStatus(int status, List<ISuite> suites) {
+        this.exit_code = (short) status;
+        this.reports = suites;
+        this.counts = new ArrayList<>(3);
+    }
+
+
+    @Override
+    public short code() {
+        return this.exit_code;
+    }
+
+    @Override
+    public int runCount() {
+        this.calculate();
+        return this.counts.get(0).intValue();
+    }
+
+    @Override
+    public int failureCount() {
+        this.calculate();
+        return this.counts.get(1).intValue();
+    }
+
+    @Override
+    public int ignoreCount() {
+        this.calculate();
+        return this.counts.get(2).intValue();
+    }
+
+    private void calculate() {
+        if (!this.counts.isEmpty()) return;
+        int passed = 0;
+        int failed = 0;
+        int skipped = 0;
+
+        for (ISuite suite : this.reports) {
+            for (ISuiteResult result : suite.getResults().values()) {
+                final ITestContext testContext = result.getTestContext();
+                passed += testContext.getPassedTests().size();
+                failed += testContext.getFailedTests().size();
+                skipped += testContext.getSkippedTests().size();
+            }
+        }
+        this.counts.add(0, passed + failed + skipped);
+        this.counts.add(1, failed);
+        this.counts.add(2, skipped);
+    }
+}

--- a/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/SunshineTestNGTest.java
+++ b/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/SunshineTestNGTest.java
@@ -1,0 +1,25 @@
+package io.github.tatools.sunshine.testng;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.testng.ISuite;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class SunshineTestNGTest {
+    @Test
+    public void runSuites() {
+        final ArrayList<ISuite> suitesHolder = new ArrayList<>();
+        final SunshineTestNG sunshineTestNG = new SunshineTestNG(suitesHolder);
+        sunshineTestNG.setTestSuites(Arrays.asList("src/test/resources/testng.xml"));
+        sunshineTestNG.run();
+        MatcherAssert.assertThat(suitesHolder, Matchers.hasSize(1));
+    }
+}

--- a/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/TestNGKernelTest.java
+++ b/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/TestNGKernelTest.java
@@ -1,0 +1,73 @@
+package io.github.tatools.sunshine.testng;
+
+import io.github.tatools.sunshine.core.FileSystemPath;
+import io.github.tatools.sunshine.core.KernelException;
+import io.github.tatools.sunshine.core.SuiteException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class TestNGKernelTest {
+
+    @Test
+    public void status() throws KernelException {
+        MatcherAssert.assertThat(
+                new TestNGKernel(() -> new FileSystemPath.Fake("src/test/resources/testng.xml")).status().code(),
+                Matchers.equalTo((short) 0)
+        );
+    }
+
+    @Test(expected = KernelException.class)
+    public void runWithFail() throws KernelException {
+        new TestNGKernel(() -> {
+            throw new SuiteException("Fail");
+        }).status();
+    }
+
+    @Test
+    public void with() throws KernelException {
+        final Listener l1 = new Listener();
+        final Listener l2 = new Listener();
+        new TestNGKernel(() -> new FileSystemPath.Fake("src/test/resources/testng.xml"))
+                .with(l1)
+                .with(l2)
+                .status();
+        MatcherAssert.assertThat(l1, Matchers.not(Matchers.equalTo(l2)));
+    }
+
+    private static final class Listener implements ISuiteListener {
+        private int status = 0;
+
+        @Override
+        public void onStart(ISuite suite) {
+            status++;
+        }
+
+        @Override
+        public void onFinish(ISuite suite) {
+            status++;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || this.getClass() != o.getClass()) return false;
+
+            TestNGKernelTest.Listener listener = (TestNGKernelTest.Listener) o;
+
+            return this.status == listener.status;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.status;
+        }
+    }
+}

--- a/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/TestNGStatusTest.java
+++ b/sunshine-testng/src/test/java/io/github/tatools/sunshine/testng/TestNGStatusTest.java
@@ -1,0 +1,59 @@
+package io.github.tatools.sunshine.testng;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.testng.ISuite;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public class TestNGStatusTest {
+    @Test
+    public void code() {
+        MatcherAssert.assertThat(
+                new TestNGStatus(4, Collections.emptyList()).code(),
+                Matchers.equalTo((short) 4)
+        );
+    }
+
+    @Test
+    public void runCount() {
+        MatcherAssert.assertThat(
+                new TestNGStatus(0, this.suites()).runCount(),
+                Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    public void failureCount() {
+        MatcherAssert.assertThat(
+                new TestNGStatus(0, this.suites()).failureCount(),
+                Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    public void ignoreCount() {
+        MatcherAssert.assertThat(
+                new TestNGStatus(0, this.suites()).ignoreCount(),
+                Matchers.equalTo(0)
+        );
+    }
+
+    private List<ISuite> suites() {
+        final ArrayList<ISuite> suitesHolder = new ArrayList<>();
+        final SunshineTestNG sunshineTestNG = new SunshineTestNG(suitesHolder);
+        sunshineTestNG.setTestSuites(Arrays.asList("src/test/resources/testng.xml"));
+        sunshineTestNG.run();
+        return suitesHolder;
+    }
+
+}


### PR DESCRIPTION
The sample outputs after applying these changes:
```
~/sunshine cd sunshine-junit4-integration-tests/build/libs/
~/sunshine/sunshine-junit4-integration-tests/build/libs java -jar sunshine-junit4-integration-tests-unspecified.jar 
The following pattern will be used for classes filtering: (.+)([Tt]est)([\w\d]+)?
Sunshine found 1 classes by the specified pattern. They all will be passed to appropriate xUnit engine.
Classes:
- io.github.tatools.junit4tests.PassedTest

===============================================
Total tests run: 1, Failures: 0, Skips: 0
===============================================

~/sunshine/sunshine-junit4-integration-tests/build/libs cd -
~/sunshine cd sunshine-testng-integration-tests/build/libs/
~/sunshine/sunshine-testng-integration-tests/build/libs java -jar sunshine-testng-integration-tests-unspecified.jar 
The following pattern will be used for classes filtering: (.+)([Tt]est)([\w\d]+)?
Sunshine found 3 classes by the specified pattern. They all will be passed to appropriate xUnit engine.
Classes:
- io.github.tatools.testngtests.PassedTest
- io.github.tatools.testngtests.TestNGXmlTest1
- io.github.tatools.testngtests.TestNGXmlTest2

===============================================
Total tests run: 3, Failures: 0, Skips: 0
===============================================
```

Resolves #81 