### PR TITLE
Reduce duplication of jacoco configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,12 @@ plugins {
 
 // configure "nexus-staging" plugin
 nexusStaging {
-    packageGroup= "io.github.tatools"
+    packageGroup = "io.github.tatools"
     delayBetweenRetriesInMillis = 60000
     username = sonatypeUsername
     password = sonatypePassword
 }
+
 
 subprojects {
     apply plugin: 'java'
@@ -23,14 +24,15 @@ subprojects {
         mavenCentral()
     }
 }
-
 project(':sunshine-core') {
+    apply from: rootProject.file('gradle/jacoco.gradle')
     dependencies {
         compileOnly project(':sunshine-core-deps')
     }
 }
 
 project(':sunshine-junit4') {
+    apply from: rootProject.file('gradle/jacoco.gradle')
     dependencies {
         compile project(':sunshine-core')
     }
@@ -43,6 +45,7 @@ project(':sunshine-junit4-integration-tests') {
 }
 
 project(':sunshine-testng') {
+    apply from: rootProject.file('gradle/jacoco.gradle')
     dependencies {
         compile project(':sunshine-core')
     }

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'jacoco'
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+}
+check.dependsOn(jacocoTestReport)

--- a/sunshine-core/build.gradle
+++ b/sunshine-core/build.gradle
@@ -1,15 +1,6 @@
-apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-jacocoTestReport {
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-}
-
-check.dependsOn(jacocoTestReport)
 
 dependencies {
     compileOnly 'org.projectlombok:lombok:1.16.14'

--- a/sunshine-junit4/build.gradle
+++ b/sunshine-junit4/build.gradle
@@ -1,15 +1,5 @@
-apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
-
-jacocoTestReport {
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-}
-
-check.dependsOn(jacocoTestReport)
 
 dependencies {
     compileOnly 'org.projectlombok:lombok:1.16.14'

--- a/sunshine-testng/build.gradle
+++ b/sunshine-testng/build.gradle
@@ -1,15 +1,5 @@
-apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
-
-jacocoTestReport {
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-}
-
-check.dependsOn(jacocoTestReport)
 
 dependencies {
     compileOnly 'org.projectlombok:lombok:1.16.14'


### PR DESCRIPTION
There is "gradle/jacoco.gradle" file which has a common configuration of
a jacoco plugin. This configuration is loaded for each sub-project which
is published.

#143