### PR TITLE
Sign archives before upload to Bintray

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -25,4 +25,4 @@ release:
   script: |-
     cp -v ../gradle.properties ../secring.gpg ./
     ./gradlew updateVersion -PnewVersion=${tag}
-    ./gradlew clean ready bintrayUpload --info
+    ./gradlew clean ready signArchives bintrayUpload --info


### PR DESCRIPTION
As signing plugin is not called automatically, we call it before
send binaries to Bintray.

#145