### PR TITLE
Upload *.asc files to Bintray

### DIFF
--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -28,6 +28,16 @@ bintray {
     key = bintrayApiKey
     publications = ['maven']
     publish = true
+    filesSpec {
+        from("${buildDir}/libs") {
+            include '*.jar.asc'
+        }
+        from("${buildDir}/publications/maven") {
+            include 'pom-default.xml.asc'
+            rename 'pom-default.xml.asc', "${project.name}-${project.version}.pom.asc"
+        }
+        into "${project.group.replaceAll(/\./, '/')}/${project.name}/${project.version}"
+    }
     pkg {
         userOrg = BINTRAY_ORG
         repo = rootProject.name


### PR DESCRIPTION
Bintray plugin doesn't support loading of ASC files but they are
required for Maven central. That's why the upload is configured to
manually load these files.

Please refer to
https://github.com/bintray/gradle-bintray-plugin/issues/255 issue to get
more details.

#145