### PR TITLE
Rename SunshineTestBase class to ClasspathBasedTest

### DIFF
--- a/sunshine-core/src/main/java/org/tatools/sunshine/core/ClasspathBasedTest.java
+++ b/sunshine-core/src/main/java/org/tatools/sunshine/core/ClasspathBasedTest.java
@@ -1,0 +1,43 @@
+package org.tatools.sunshine.core;
+
+import lombok.EqualsAndHashCode;
+
+/**
+ * The class represents a classpath file as a test in form of Java class.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ */
+@EqualsAndHashCode
+public final class ClasspathBasedTest implements SunshineTest {
+    private final String path;
+
+    /**
+     * Construct the new instance.
+     *
+     * @param path is a relative path in a file system which includes class name (like {@code org/my/tests/Test1}).
+     *             It has to be relative to current classpath. It can have {@code .class} extension or not.
+     */
+    public ClasspathBasedTest(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public Class object() throws TestException {
+        try {
+            return Class.forName(toString());
+        } catch (ClassNotFoundException e) {
+            throw new TestException(e);
+        }
+    }
+
+    @Override
+    public boolean match(Condition condition) {
+        return condition.applicable(this.toString());
+    }
+
+    @Override
+    public String toString() {
+        return path.replaceAll("[/\\\\]", ".").replaceFirst("^\\.", "").replace(".class", "");
+    }
+}

--- a/sunshine-core/src/main/java/org/tatools/sunshine/core/SunshineSuiteBase.java
+++ b/sunshine-core/src/main/java/org/tatools/sunshine/core/SunshineSuiteBase.java
@@ -20,7 +20,7 @@ public final class SunshineSuiteBase implements SunshineSuite {
     public List<SunshineTest> tests() throws SuiteException {
         try {
             return fileSystem.files().stream()
-                    .map(f -> new SunshineTestBase(f.path().toString()))
+                    .map(f -> new ClasspathBasedTest(f.path().toString()))
                     .collect(Collectors.toList());
         } catch (FileSystemException e) {
             throw new SuiteException(e);

--- a/sunshine-core/src/main/java/org/tatools/sunshine/core/SunshineTest.java
+++ b/sunshine-core/src/main/java/org/tatools/sunshine/core/SunshineTest.java
@@ -1,6 +1,8 @@
 package org.tatools.sunshine.core;
 
 /**
+ * The interface represents a test like a Java class.
+ *
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$
  * @since 0.1

--- a/sunshine-core/src/main/java/org/tatools/sunshine/core/SunshineTestBase.java
+++ b/sunshine-core/src/main/java/org/tatools/sunshine/core/SunshineTestBase.java
@@ -6,31 +6,29 @@ import lombok.EqualsAndHashCode;
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @deprecated use {@link ClasspathBasedTest} instead of.
  */
+@Deprecated
 @EqualsAndHashCode
 public final class SunshineTestBase implements SunshineTest {
-    private final String path;
+    private final SunshineTest origin;
 
     public SunshineTestBase(String path) {
-        this.path = path;
+        this.origin = new ClasspathBasedTest(path);
     }
 
     @Override
     public Class object() throws TestException {
-        try {
-            return Class.forName(toString());
-        } catch (ClassNotFoundException e) {
-            throw new TestException(e);
-        }
+        return this.origin.object();
     }
 
     @Override
     public boolean match(Condition condition) {
-        return condition.applicable(this.toString());
+        return this.origin.match(condition);
     }
 
     @Override
     public String toString() {
-        return path.replaceAll("[/\\\\]", ".").replaceFirst("^\\.", "").replace(".class", "");
+        return this.origin.toString();
     }
 }

--- a/sunshine-core/src/main/java/org/tatools/sunshine/core/Test.java
+++ b/sunshine-core/src/main/java/org/tatools/sunshine/core/Test.java
@@ -1,7 +1,7 @@
 package org.tatools.sunshine.core;
 
 /**
- * The interface represents a class with a test.
+ * The interface represents a test like an generic object.
  *
  * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
  * @version $Id$

--- a/sunshine-core/src/test/java/org/tatools/sunshine/core/ClasspathBasedTestTest.java
+++ b/sunshine-core/src/test/java/org/tatools/sunshine/core/ClasspathBasedTestTest.java
@@ -1,0 +1,37 @@
+package org.tatools.sunshine.core;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @version $Id$
+ * @since 0.1
+ */
+public class ClasspathBasedTestTest {
+
+    @Test
+    public void object() throws TestException {
+        MatcherAssert.assertThat(
+                new ClasspathBasedTest("org/tatools/sunshine/core/ClasspathBasedTest.class").object(),
+                Matchers.equalTo(ClasspathBasedTest.class)
+        );
+    }
+
+    @Test
+    public void testToStringWithClassExtension() {
+        MatcherAssert.assertThat(
+                new ClasspathBasedTest("org/tatools/sunshine/core/ClasspathBasedTest.class").toString(),
+                Matchers.equalTo("org.tatools.sunshine.core.ClasspathBasedTest")
+        );
+    }
+
+    @Test
+    public void testToStringWithoutClassExtension() {
+        MatcherAssert.assertThat(
+                new ClasspathBasedTest("org/tatools/sunshine/core/ClasspathBasedTest").toString(),
+                Matchers.equalTo("org.tatools.sunshine.core.ClasspathBasedTest")
+        );
+    }
+}

--- a/sunshine-core/src/test/java/org/tatools/sunshine/core/SunshineTestTestBase.java
+++ b/sunshine-core/src/test/java/org/tatools/sunshine/core/SunshineTestTestBase.java
@@ -20,9 +20,17 @@ public class SunshineTestTestBase {
     }
 
     @Test
-    public void toStringImpl() {
+    public void testToStringWithClassExtension() {
         MatcherAssert.assertThat(
                 new SunshineTestBase("org/tatools/sunshine/core/SunshineTestBase.class").toString(),
+                Matchers.equalTo("org.tatools.sunshine.core.SunshineTestBase")
+        );
+    }
+
+    @Test
+    public void testToStringWithoutClassExtension() {
+        MatcherAssert.assertThat(
+                new SunshineTestBase("org/tatools/sunshine/core/SunshineTestBase").toString(),
                 Matchers.equalTo("org.tatools.sunshine.core.SunshineTestBase")
         );
     }

--- a/sunshine-testng/src/main/java/org/tatools/sunshine/testng/TestNGTest.java
+++ b/sunshine-testng/src/main/java/org/tatools/sunshine/testng/TestNGTest.java
@@ -19,7 +19,7 @@ final class TestNGTest implements Test<XmlTest> {
     }
 
     TestNGTest(String clazz) {
-        this(new SunshineTestBase(clazz));
+        this(new ClasspathBasedTest(clazz));
     }
 
     @Override


### PR DESCRIPTION
The change is made to build more obvious and unambiguous namespace.

The rename was made using deprecation mechanism. This means the old
class is still available, however, a new one is used in the code.

#137